### PR TITLE
optimize erDiagram parser and table width

### DIFF
--- a/.changeset/dirty-wasps-cheer.md
+++ b/.changeset/dirty-wasps-cheer.md
@@ -1,0 +1,7 @@
+---
+'@pintora/diagrams': patch
+'@pintora/cli': patch
+'@pintora/standalone': patch
+---
+
+optimize: adjust er diagram width when minEntityWidth is larger than attributes width sum

--- a/.changeset/dry-cars-walk.md
+++ b/.changeset/dry-cars-walk.md
@@ -1,0 +1,7 @@
+---
+'@pintora/diagrams': patch
+'@pintora/cli': patch
+'@pintora/standalone': patch
+---
+
+optimize: erDiagram can have '{}' with 0 attributes

--- a/packages/pintora-diagrams/src/component/artist.ts
+++ b/packages/pintora-diagrams/src/component/artist.ts
@@ -313,7 +313,6 @@ function drawGroupsTo(parentMark: Group, ir: ComponentDiagramIR, g: LayoutGraph)
               lineWidth: conf.groupBorderWidth,
             },
           })
-          console.log('bgMark', bgMark)
           if (bgMark) {
             // console.log('bgMark', groupId, bgMark, 'bounds', bgMark.symbolBounds)
             // node.outerTop = bgMark.symbolBounds.top + y

--- a/packages/pintora-diagrams/src/er/artist.ts
+++ b/packages/pintora-diagrams/src/er/artist.ts
@@ -253,7 +253,9 @@ const drawAttributes = (group: Group, entityText: Text, attributes: Entity['attr
       })
     }
 
-    tableBuilder.rows.forEach((row, i) => {
+    const cellOrderKeys = Object.keys(CELL_ORDER)
+
+    tableBuilder.rows.forEach(row => {
       const rowSegs: Text[] = row.map(v => v.mark)
 
       const rowTextHeight = rowSegs.reduce((out, mark) => Math.max(out, mark.attrs.height), 0)
@@ -265,7 +267,9 @@ const drawAttributes = (group: Group, entityText: Text, attributes: Entity['attr
       const rowGroup = makeEmptyGroup()
       attributeGroup.children.push(rowGroup)
 
-      Object.keys(CELL_ORDER).forEach(name => {
+      let lastColumnRect: Rect
+      let rectWidthSum = 0
+      cellOrderKeys.forEach(name => {
         if (!columnMaxWidths[name]) return
         const cell = row.getCell(name)
         const offsetX = cellOffsets[name]
@@ -277,11 +281,18 @@ const drawAttributes = (group: Group, entityText: Text, attributes: Entity['attr
         })
         // console.table({ offsetX, heightOffset, rowHeight, width: rect.attrs.width, alignY })
         rowGroup.children.push(rect)
+        rectWidthSum += rect.attrs.width
+        lastColumnRect = rect
         if (cell) {
           rowGroup.children.push(cell.mark)
           cell.mark.matrix = mat3.fromTranslation(mat3.create(), [offsetX + attribPaddingX, alignY])
         }
       })
+
+      if (lastColumnRect) {
+        // to make sure last rect's right bound reaches entity's right bound
+        lastColumnRect.attrs.width += Math.max(0, bBox.width - rectWidthSum)
+      }
 
       const nodeUnitHeights = row.map(v => v?.mark.attrs.height || 0)
 

--- a/packages/pintora-diagrams/src/er/config.ts
+++ b/packages/pintora-diagrams/src/er/config.ts
@@ -42,8 +42,7 @@ export const defaultConfig: ErConf = {
   edgeType: 'polyline',
   useMaxWidth: false,
 
-  minEntityWidth: 90,
-
+  minEntityWidth: 80,
   minEntityHeight: 50,
 
   entityPaddingX: 15,

--- a/packages/pintora-diagrams/src/er/parser/erDiagram.ne
+++ b/packages/pintora-diagrams/src/er/parser/erDiagram.ne
@@ -74,10 +74,12 @@ statement ->
       const sub = d[0]
       yy.addInheritance(sup, sub)
     } %}
-  | entityName __ "{" __ attributes _ "}" %NL {%
+  | entityName __ "{" __ attributes:? _ "}" %NL {%
       function(d) {
         yy.addEntity(d[0]);
-        yy.addAttributes(d[0], d[4]);
+        if (d[4]) {
+          yy.addAttributes(d[0], d[4]);
+        }
       }
     %}
   | entityName "{" "}" %NL {% (d) => yy.addEntity(d[0]) %}


### PR DESCRIPTION
- optimize: adjust er diagram width when minEntityWidth is larger than attributes width sum
- optimize: erDiagram can have '{}' with 0 attributes
