### PR TITLE
feat: support `title: text` for some diagrams

### DIFF
--- a/.changeset/dry-apples-hide.md
+++ b/.changeset/dry-apples-hide.md
@@ -1,0 +1,6 @@
+---
+'@pintora/diagrams': patch
+'@pintora/test-shared': patch
+---
+
+feat: [activityDiagram] support `title: text` for diagram title

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "*.ts": [
       "prettier --write",
       "eslint --fix"
+    ],
+    "*.js": [
+      "prettier --write",
+      "eslint --fix"
     ]
   },
   "packageManager": "pnpm@7.9.3",

--- a/packages/pintora-diagrams/shared-grammars/config.d.ts
+++ b/packages/pintora-diagrams/shared-grammars/config.d.ts
@@ -15,3 +15,9 @@ export type OverrideConfigAction<T = unknown> =
       type: 'overrideConfig'
       error: Error
     }
+
+/** action type for `title` statement */
+export type SetTitleAction = {
+  type: 'setTitle'
+  text: string
+}

--- a/packages/pintora-diagrams/src/activity/__tests__/activity-parser.spec.js
+++ b/packages/pintora-diagrams/src/activity/__tests__/activity-parser.spec.js
@@ -701,4 +701,15 @@ repeatwhile (data available) is (yes) not (no)
       },
     })
   })
+
+  it('can parse title', () => {
+    const example = stripStartEmptyLines(`
+  activityDiagram
+  title: Hello
+  :do something;
+  `)
+    parse(example)
+    const ir = db.getDiagramIR()
+    expect(ir.title).toEqual('Hello')
+  })
 })

--- a/packages/pintora-diagrams/src/activity/artist.ts
+++ b/packages/pintora-diagrams/src/activity/artist.ts
@@ -16,6 +16,9 @@ import {
   unique,
   compact,
   Bounds,
+  IFont,
+  TSize,
+  Maybe,
 } from '@pintora/core'
 import {
   Action,
@@ -117,6 +120,27 @@ const erArtist: IDiagramArtist<ActivityDiagramIR, ActivityConf> = {
     const { bounds: edgeBounds } = drawEdges(rootMark, g)
 
     const bounds = tryExpandBounds(dagreWrapper.getGraphBounds(), edgeBounds)
+    const { title } = ir
+    let titleSize: Maybe<TSize> = undefined
+    if (title) {
+      const titleFont: IFont = { fontSize: conf.fontSize, fontFamily: conf.fontFamily }
+      titleSize = calculateTextDimensions(title, titleFont)
+      const titleHeight = titleSize.height
+      rootMark.children.push({
+        type: 'text',
+        attrs: {
+          text: title,
+          x: bounds.left + bounds.width / 2,
+          y: -titleHeight,
+          ...titleFont,
+          fill: conf.textColor,
+          textAlign: 'center',
+          fontWeight: 'bold',
+        },
+        class: 'activity__title',
+      })
+      titleSize.height += conf.fontSize
+    }
 
     // console.log('bounds', bounds)
     const { width, height } = adjustRootMarkBounds({
@@ -126,6 +150,7 @@ const erArtist: IDiagramArtist<ActivityDiagramIR, ActivityConf> = {
       padY: conf.diagramPadding,
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
+      titleSize,
     })
 
     return {

--- a/packages/pintora-diagrams/src/activity/db.ts
+++ b/packages/pintora-diagrams/src/activity/db.ts
@@ -1,7 +1,7 @@
 import { makeIdCounter } from '@pintora/core'
 import { BaseDb } from '../util/base-db'
 import { BaseDiagramIR } from '../util/ir'
-import { OverrideConfigAction, ParamAction } from '../util/config'
+import { OverrideConfigAction, ParamAction, SetTitleAction } from '../util/config'
 import { dedent } from '../util/text'
 
 export type Action = {
@@ -179,6 +179,7 @@ export type ApplyPart =
       type: 'forkBranch'
       children: ApplyPart[]
     }
+  | SetTitleAction
 
 type DbApplyState = {
   prevStepId?: string | undefined
@@ -338,6 +339,10 @@ class ActivityDb extends BaseDb {
           value.target = prevStepId
         }
         this.arrowLabels.push(value)
+        break
+      }
+      case 'setTitle': {
+        this.title = part.text
         break
       }
       case 'addParam': {

--- a/packages/pintora-diagrams/src/activity/parser/activityDiagram.ne
+++ b/packages/pintora-diagrams/src/activity/parser/activityDiagram.ne
@@ -104,6 +104,7 @@ statement ->
   | forkSentence
   | noteStatement
   | arrowLabelStatement
+  | titleStatement
   | paramStatement _ %NL
   | configStatement _ %NL
   | comment _ %NL {% null %}
@@ -316,3 +317,6 @@ arrowLabelStatement ->
         return { type: 'arrowLabel', text: d[2] } as ApplyPart
       }
     %}
+
+titleStatement ->
+	  "title" %COLON words %NL {% (d) => ({ type: 'setTitle', text: d[2].trim() }) %}

--- a/packages/pintora-diagrams/src/component/__tests__/__snapshots__/component-artist.spec.js.snap
+++ b/packages/pintora-diagrams/src/component/__tests__/__snapshots__/component-artist.spec.js.snap
@@ -741,6 +741,18 @@ exports[`component-artist match example snapshot 1`] = `
         ],
         "type": "group",
       },
+      {
+        "attrs": {
+          "fill": "#3b4044",
+          "fontFamily": "Source Code Pro, sans-serif",
+          "fontSize": 14,
+          "fontWeight": "bold",
+          "text": "Component Diagram Example",
+          "textAlign": "center",
+        },
+        "class": "component__title",
+        "type": "text",
+      },
     ],
     "type": "group",
   },

--- a/packages/pintora-diagrams/src/component/__tests__/component-parser.spec.js
+++ b/packages/pintora-diagrams/src/component/__tests__/component-parser.spec.js
@@ -307,4 +307,15 @@ componentDiagram
     const ir = db.getDiagramIR()
     expect(ir.interfaces).toEqual({})
   })
+
+  it('can parse title', () => {
+    const example = stripStartEmptyLines(`
+componentDiagram
+  title: Hello
+  %% comment here
+  `)
+    parse(example)
+    const ir = db.getDiagramIR()
+    expect(ir.title).toEqual('Hello')
+  })
 })

--- a/packages/pintora-diagrams/src/component/artist.ts
+++ b/packages/pintora-diagrams/src/component/artist.ts
@@ -12,6 +12,7 @@ import {
   GSymbol,
   IFont,
   Bounds,
+  Maybe,
 } from '@pintora/core'
 import { ComponentDiagramIR, LineType, Relationship } from './db'
 import { ComponentConf, getConf } from './config'
@@ -86,6 +87,28 @@ const componentArtist: IDiagramArtist<ComponentDiagramIR, ComponentConf> = {
     const gBounds = tryExpandBounds(dagreWrapper.getGraphBounds(), labelBounds)
     const pad = conf.diagramPadding
 
+    const { title } = ir
+    let titleSize: Maybe<TSize> = undefined
+    if (title) {
+      const titleFont: IFont = { fontSize: conf.fontSize, fontFamily: conf.fontFamily }
+      titleSize = calculateTextDimensions(title, titleFont)
+      const titleHeight = titleSize.height
+      rootMark.children.push({
+        type: 'text',
+        attrs: {
+          text: title,
+          x: gBounds.left + gBounds.width / 2,
+          y: -titleHeight,
+          ...titleFont,
+          fill: conf.textColor,
+          textAlign: 'center',
+          fontWeight: 'bold',
+        },
+        class: 'component__title',
+      })
+      titleSize.height += conf.fontSize
+    }
+
     const { width, height } = adjustRootMarkBounds({
       rootMark,
       gBounds,
@@ -93,6 +116,7 @@ const componentArtist: IDiagramArtist<ComponentDiagramIR, ComponentConf> = {
       padY: pad,
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
+      titleSize,
     })
 
     return {

--- a/packages/pintora-diagrams/src/component/db.ts
+++ b/packages/pintora-diagrams/src/component/db.ts
@@ -1,6 +1,6 @@
 import { BaseDb } from '../util/base-db'
 import { BaseDiagramIR } from '../util/ir'
-import { OverrideConfigAction, ParamAction } from '../util/config'
+import { OverrideConfigAction, ParamAction, SetTitleAction } from '../util/config'
 
 type Component = {
   name: string
@@ -66,6 +66,7 @@ type ApplyPart =
       label?: string
       children: UMLElement[]
     }
+  | SetTitleAction
 
 export type ComponentDiagramIR = BaseDiagramIR & {
   components: Record<string, Component>
@@ -128,6 +129,10 @@ class ComponentDb extends BaseDb {
       }
       case 'overrideConfig': {
         this.addOverrideConfig(part)
+        break
+      }
+      case 'setTitle': {
+        this.title = part.text
         break
       }
       default: {

--- a/packages/pintora-diagrams/src/component/index.ts
+++ b/packages/pintora-diagrams/src/component/index.ts
@@ -9,7 +9,7 @@ export type { ComponentConf, ComponentDiagramIR }
 export const componentDiagram: IDiagram<ComponentDiagramIR, ComponentConf> = {
   pattern: /^\s*componentDiagram/,
   parser: {
-    parse(text, config) {
+    parse(text) {
       parse(text)
       db.fillMissingElements()
       return db.getDiagramIR()

--- a/packages/pintora-diagrams/src/component/parser/componentDiagram.ne
+++ b/packages/pintora-diagrams/src/component/parser/componentDiagram.ne
@@ -81,6 +81,7 @@ statement ->
       }
     %}
   | paramStatement %NL
+  | "title" %COLON words %NL {% (d) => ({ type:'setTitle', text: d[2].trim() }) %}
   | configOpenCloseStatement %NL
   | comment %NL
 
@@ -199,19 +200,26 @@ interface ->
 interfaceStart -> ("interface" | "()")
 
 relationship ->
-    elementReference _ relationLine _ elementReference (__ %COLON __ (%VALID_TEXT | %WS):+):? %NL {%
+    elementReference _ relationLine _ elementReference (__ %COLON __ words):? %NL {%
       function(d) {
         // console.log('[relationship] with message', d)
         const from = d[0]
         const to = d[4]
         let message
         if (d[5]) {
-          message = d[5][3].map(a => a[0]).map(o => tv(o)).join('')
+          message = d[5][3]
         }
         const line = d[2]
         const obj = { from, to, line, message }
         yy.addRelationship(obj)
         return obj
+      }
+    %}
+
+words ->
+    (%VALID_TEXT | %WS):+ {%
+      function(d) {
+        return d[0].map(o => tv(o[0])).join('').trim()
       }
     %}
 

--- a/packages/pintora-diagrams/src/dot/__tests__/__snapshots__/dot-artist.spec.js.snap
+++ b/packages/pintora-diagrams/src/dot/__tests__/__snapshots__/dot-artist.spec.js.snap
@@ -197,6 +197,18 @@ exports[`dot-artist match example snapshot 1`] = `
         },
         "type": "text",
       },
+      {
+        "attrs": {
+          "fill": "#3b4044",
+          "fontFamily": "Source Code Pro, sans-serif",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "text": "Dot Diagram Example",
+          "textAlign": "center",
+          "textBaseline": "hanging",
+        },
+        "type": "text",
+      },
     ],
     "type": "group",
   },

--- a/packages/pintora-diagrams/src/er/__tests__/er-parser.spec.js
+++ b/packages/pintora-diagrams/src/er/__tests__/er-parser.spec.js
@@ -132,4 +132,15 @@ erDiagram
     const ir = db.getDiagramIR()
     expect(Object.keys(ir.entities).length).toBe(0)
   })
+
+  it('can parse title', () => {
+    const example = stripStartEmptyLines(`
+erDiagram
+  title: Hello
+  %% comment here
+  `)
+    parse(example)
+    const ir = db.getDiagramIR()
+    expect(ir.title).toEqual('Hello')
+  })
 })

--- a/packages/pintora-diagrams/src/er/artist.ts
+++ b/packages/pintora-diagrams/src/er/artist.ts
@@ -9,6 +9,9 @@ import {
   Rect,
   PathCommand,
   Point,
+  Maybe,
+  TSize,
+  IFont,
 } from '@pintora/core'
 import { ErDiagramIR, Identification, Entity, Relationship } from './db'
 import { ErConf, getConf } from './config'
@@ -99,18 +102,41 @@ const erArtist: IDiagramArtist<ErDiagramIR, ErConf> = {
     })
     rootMark.children.unshift(relationsGroup)
 
-    const gBounds = dagreWrapper.getGraphBounds()
-    tryExpandBounds(gBounds, relationshipsBounds)
+    const bounds = dagreWrapper.getGraphBounds()
+    tryExpandBounds(bounds, relationshipsBounds)
 
     const pad = conf.diagramPadding
 
+    const { title } = ir
+    let titleSize: Maybe<TSize> = undefined
+    if (title) {
+      const titleFont: IFont = { fontSize: conf.fontSize, fontFamily: conf.fontFamily }
+      titleSize = getTextDimensionsInPresicion(title, titleFont)
+      const titleHeight = titleSize.height
+      rootMark.children.push({
+        type: 'text',
+        attrs: {
+          text: title,
+          x: bounds.left + bounds.width / 2,
+          y: -titleHeight,
+          ...titleFont,
+          fill: conf.textColor,
+          textAlign: 'center',
+          fontWeight: 'bold',
+        },
+        class: 'er__title',
+      })
+      titleSize.height += conf.fontSize
+    }
+
     const { width, height } = adjustRootMarkBounds({
       rootMark,
-      gBounds,
+      gBounds: bounds,
       padX: pad,
       padY: pad,
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
+      titleSize,
     })
 
     return {

--- a/packages/pintora-diagrams/src/er/db.ts
+++ b/packages/pintora-diagrams/src/er/db.ts
@@ -83,12 +83,14 @@ export class ErDb extends BaseDb {
   }
   getDiagramIR(): ErDiagramIR {
     return {
+      ...super.getBaseDiagramIR(),
       entities: this.entities,
       relationships: this.relationships,
-      configParams: this.configParams,
-      overrideConfig: this.overrideConfig,
       inheritances: this.inheritances,
     }
+  }
+  addTitle(title: string) {
+    this.title = title
   }
   addAttributes(name: string, attributes: Attribute[]) {
     const entity = this.addEntity(name)
@@ -104,6 +106,7 @@ export class ErDb extends BaseDb {
     this.relationships = []
     this.inheritances = []
     this.configParams = []
+    this.title = ''
   }
 }
 

--- a/packages/pintora-diagrams/src/er/parser/erDiagram.ne
+++ b/packages/pintora-diagrams/src/er/parser/erDiagram.ne
@@ -84,6 +84,7 @@ statement ->
     %}
   | entityName "{" "}" %NL {% (d) => yy.addEntity(d[0]) %}
   | entityName %WS:* %NL {% (d) => yy.addEntity(d[0]) %}
+  | titleStatement
 
   | paramStatement %WS:* %NL {%
       function(d) {
@@ -150,3 +151,13 @@ role ->
         return getQuotedWord(d[0])
       } %}
     | %VALID_TEXT {% (d) => tv(d[0]) %}
+
+titleStatement ->
+	  "title" %COLON words %NL {% (d) => { yy.addTitle(d[2].trim()) } %}
+
+words ->
+    (%VALID_TEXT | %WS):+ {%
+      function(d) {
+        return d[0].map(o => tv(o[0])).join('')
+      }
+    %}

--- a/packages/pintora-diagrams/src/mindmap/__tests__/mindmap-parser.spec.js
+++ b/packages/pintora-diagrams/src/mindmap/__tests__/mindmap-parser.spec.js
@@ -157,4 +157,15 @@ describe('mindmap parser', () => {
     // console.log('ir', JSON.stringify(ir, null, 2))
     expect(Object.keys(ir.trees[0].nodes).length).toBe(2)
   })
+
+  it('can parse title', () => {
+    const example = stripStartEmptyLines(`
+    mindmap
+      title: Hello
+      %% comment here
+      `)
+    parse(example)
+    const ir = db.getDiagramIR()
+    expect(ir.title).toEqual('Hello')
+  })
 })

--- a/packages/pintora-diagrams/src/mindmap/artist.ts
+++ b/packages/pintora-diagrams/src/mindmap/artist.ts
@@ -8,6 +8,8 @@ import {
   Bounds,
   Point,
   IFont,
+  Maybe,
+  TSize,
 } from '@pintora/core'
 import { MindmapIR, MMItem, MMTree } from './db'
 import { MindmapConf, getConf } from './config'
@@ -40,6 +42,29 @@ const mmArtist: IDiagramArtist<MindmapIR, MindmapConf> = {
     mmDraw.drawTo(rootMark)
 
     const bounds = mmDraw.dagreWrapper.getGraphBounds()
+    const { title } = ir
+    let titleSize: Maybe<TSize> = undefined
+    if (title) {
+      const fontSize = conf.maxFontSize
+      const titleFont: IFont = { fontSize, fontFamily: conf.fontFamily }
+      titleSize = calculateTextDimensions(title, titleFont)
+      const titleHeight = titleSize.height
+      rootMark.children.push({
+        type: 'text',
+        attrs: {
+          text: title,
+          x: bounds.left + bounds.width / 2,
+          y: -titleHeight,
+          ...titleFont,
+          fill: conf.textColor,
+          textAlign: 'center',
+          fontWeight: 'bold',
+        },
+        class: 'component__title',
+      })
+      titleSize.height += fontSize
+    }
+
     const { width, height } = adjustRootMarkBounds({
       rootMark,
       gBounds: bounds,
@@ -47,6 +72,7 @@ const mmArtist: IDiagramArtist<MindmapIR, MindmapConf> = {
       padY: conf.diagramPadding,
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
+      titleSize,
     })
     return {
       width,

--- a/packages/pintora-diagrams/src/mindmap/db.ts
+++ b/packages/pintora-diagrams/src/mindmap/db.ts
@@ -1,7 +1,7 @@
 import { makeIdCounter } from '@pintora/core'
 import { BaseDb } from '../util/base-db'
 import { BaseDiagramIR } from '../util/ir'
-import { OverrideConfigAction, ParamAction } from '../util/config'
+import { OverrideConfigAction, ParamAction, SetTitleAction } from '../util/config'
 
 export type LevelNotation = {
   depth: number
@@ -21,6 +21,9 @@ export interface IMMDataTree {
   nodes: Record<string, MMItem>
 }
 
+/**
+ * Mindmap tree to store data
+ */
 export class MMTree {
   root: MMItem
   private current: MMItem
@@ -97,6 +100,7 @@ export class MMTree {
 export type ApplyPart =
   | ParamAction
   | OverrideConfigAction
+  | SetTitleAction
   | {
       type: 'addItem'
       depth: number
@@ -155,6 +159,10 @@ class MindmapDb extends BaseDb {
       }
       case 'addParam': {
         this.configParams.push(part)
+        break
+      }
+      case 'setTitle': {
+        this.title = part.text
         break
       }
       case 'overrideConfig': {

--- a/packages/pintora-diagrams/src/mindmap/parser/mindmap.ne
+++ b/packages/pintora-diagrams/src/mindmap/parser/mindmap.ne
@@ -86,6 +86,7 @@ statement ->
     %}
   | paramStatement _ %NL
   | configOpenCloseStatement _ %NL
+  | "title" %COLON words %NL {% (d) => ({ type:'setTitle', text: d[2].trim() }) %}
   | comment _ %NL
 
 levelNotation ->

--- a/packages/pintora-diagrams/src/sequence/__tests__/__snapshots__/sequence-artist.spec.ts.snap
+++ b/packages/pintora-diagrams/src/sequence/__tests__/__snapshots__/sequence-artist.spec.ts.snap
@@ -972,6 +972,18 @@ exports[`sequence-artist match example snapshot 1`] = `
         "itemId": "actor-Pintora",
         "type": "group",
       },
+      {
+        "attrs": {
+          "fill": "#3b4044",
+          "fontFamily": "Source Code Pro, sans-serif",
+          "fontSize": 16,
+          "fontWeight": "bold",
+          "text": "Sequence Diagram Example",
+          "textAlign": "center",
+        },
+        "class": "sequence__title",
+        "type": "text",
+      },
     ],
     "type": "group",
   },

--- a/packages/pintora-diagrams/src/util/artist-util.ts
+++ b/packages/pintora-diagrams/src/util/artist-util.ts
@@ -142,6 +142,7 @@ export function adjustRootMarkBounds({
   padY,
   containerSize,
   useMaxWidth,
+  titleSize,
 }: {
   rootMark: Group
   gBounds: Bounds
@@ -149,18 +150,21 @@ export function adjustRootMarkBounds({
   padY: number
   containerSize?: DiagramArtistOptions['containerSize']
   useMaxWidth?: boolean
+  titleSize?: TSize
 }) {
   const containerWidth = containerSize?.width
   const doublePadX = padX * 2
-  const scaleX = useMaxWidth && containerWidth ? containerWidth / (gBounds.width + doublePadX) : 1
+  const titleHeight = titleSize?.height || 0
+  const titleWidth = titleSize?.width || 0
+  const scaleX = useMaxWidth && containerWidth ? containerWidth / Math.max(gBounds.width + doublePadX, titleWidth) : 1
   rootMark.matrix = mat3.translate(mat3.create(), mat3.fromScaling(mat3.create(), [scaleX, scaleX]), [
     -Math.min(0, gBounds.left) + padX / scaleX,
-    -Math.min(0, gBounds.top) + padY / scaleX,
+    -Math.min(0, gBounds.top) + padY / scaleX + titleHeight,
   ])
-  const width = (gBounds.width + doublePadX) * scaleX
+  const width = Math.max(gBounds.width + doublePadX, titleWidth) * scaleX
   return {
     width,
-    height: gBounds.height * scaleX + padY * 2,
+    height: gBounds.height * scaleX + padY * 2 + (titleSize?.height || 0),
   }
 }
 

--- a/packages/pintora-diagrams/src/util/base-db.ts
+++ b/packages/pintora-diagrams/src/util/base-db.ts
@@ -5,6 +5,7 @@ import { ConfigParam, OverrideConfigAction } from './config'
 export class BaseDb {
   configParams: ConfigParam[] = []
   overrideConfig: Partial<PintoraConfig> = {}
+  title = ''
 
   addOverrideConfig(action: OverrideConfigAction) {
     if ('error' in action) {
@@ -18,12 +19,14 @@ export class BaseDb {
     return {
       configParams: this.configParams,
       overrideConfig: this.overrideConfig,
+      title: this.title,
     }
   }
 
   clear() {
     this.configParams = []
     this.overrideConfig = {}
+    this.title = ''
   }
 }
 

--- a/packages/pintora-diagrams/src/util/config.ts
+++ b/packages/pintora-diagrams/src/util/config.ts
@@ -3,7 +3,7 @@ import { ConfigParam, ConfigMeta, interpreteConfigs, PintoraConfig, safeAssign, 
 export type { ConfigParam, ConfigMeta }
 export { interpreteConfigs }
 
-export type { ParamAction, OverrideConfigAction } from '../../shared-grammars/config'
+export type { ParamAction, OverrideConfigAction, SetTitleAction } from '../../shared-grammars/config'
 
 /**
  * How edges are routed

--- a/packages/pintora-diagrams/src/util/ir.ts
+++ b/packages/pintora-diagrams/src/util/ir.ts
@@ -2,6 +2,7 @@ import { PintoraConfig } from '@pintora/core'
 import { ConfigParam } from './config'
 
 export type BaseDiagramIR = {
+  title?: string
   configParams: ConfigParam[]
   overrideConfig: Partial<PintoraConfig>
 }

--- a/packages/test-shared/src/data/examples.ts
+++ b/packages/test-shared/src/data/examples.ts
@@ -6,6 +6,7 @@ export const sequenceExample: DiagramExample = {
   description: 'Sample',
   code: stripStartEmptyLines(`
 sequenceDiagram
+  title: Sequence Diagram Example
   autonumber
   User->>Pintora: render this
   activate Pintora
@@ -39,6 +40,8 @@ export const erExample: DiagramExample = {
   description: 'Sample for erDiagram',
   code: stripStartEmptyLines(`
 erDiagram
+  title: Entity Relationship Example
+
   PERSON {
     string phone "phone number"
   }
@@ -186,6 +189,8 @@ export const componentExample: DiagramExample = {
   description: 'Sample for a componentDiagram',
   code: stripStartEmptyLines(`
 componentDiagram
+  title: Component Diagram Example
+
   package "@pintora/core" {
     () GraphicsIR
     () IRenderer
@@ -220,6 +225,7 @@ const activityExample: DiagramExample = {
   description: 'Sample for a activityDiagram',
   code: stripStartEmptyLines(`
 activityDiagram
+title: Activity Example
 start
 partition Init {
   :read config;
@@ -256,6 +262,7 @@ export const mindmapExample: DiagramExample = {
   description: 'Sample for a mindmap',
   code: stripStartEmptyLines(`
 mindmap
+title: Mind Map Example
 + UML Diagrams
 ++ Behavior Diagrams
 +++ Sequence Diagram
@@ -293,6 +300,7 @@ export const dotExample: DiagramExample = {
 dotDiagram
   digraph G {
     bgcolor="white"
+    label="Dot Diagram Example"
 
     // specify common node attributes
     node [color="#111",bgcolor=orange]

--- a/website/docs/diagrams/activity-diagram.mdx
+++ b/website/docs/diagrams/activity-diagram.mdx
@@ -15,6 +15,7 @@ Simple action starts with `:` and ends with `;`, with description between them.
 
 ```pintora play
 activityDiagram
+  title: Activity Diagram Simple Action
   :Action 1;
   :Action 2;
 ```

--- a/website/docs/diagrams/component-diagram.mdx
+++ b/website/docs/diagrams/component-diagram.mdx
@@ -15,6 +15,8 @@ And you can define an alias, using the `as` keyword. This alias will be used lat
 
 ```pintora play
 componentDiagram
+  title: Component Diagram Components and Interfaces
+
   component comp1
   [comp2]
   [component 3] as comp3

--- a/website/docs/diagrams/er-diagram.mdx
+++ b/website/docs/diagrams/er-diagram.mdx
@@ -21,6 +21,7 @@ The syntax is based on [Mermaid](https://mermaid-js.github.io/mermaid/#/entityRe
 
 ```pintora play
 erDiagram
+  title: Entity Relationship Example
   CUSTOMER {
     int id PK
     int address FK

--- a/website/docs/diagrams/mindmap.mdx
+++ b/website/docs/diagrams/mindmap.mdx
@@ -12,6 +12,7 @@ You can specify node level by number of `*` symobl, starting from 1.
 
 ```pintora play
 mindmap
+title: Mind Map levels
 * UML Diagrams
 ** Behavior Diagrams
 *** Sequence Diagram

--- a/website/docs/diagrams/sequence-diagram.mdx
+++ b/website/docs/diagrams/sequence-diagram.mdx
@@ -19,6 +19,7 @@ The syntax is based on Mermaid 8.9, with some other good stuff:
 
 ```pintora play
 sequenceDiagram
+  title: Sequence Diagram Example
   autonumber
   participant [<actor> User]
   User->>Pintora: Draw me a sequence diagram（with DSL）

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/diagrams/sequence-diagram.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/diagrams/sequence-diagram.mdx
@@ -19,6 +19,7 @@ title: Sequence Diagram 时序图
 
 ```pintora play
 sequenceDiagram
+  title: 时序图例子
   autonumber
   participant [<actor> 用户]
   用户->>Pintora: 帮我画张时序图（图表 DSL）

--- a/website/static/data/pintora.tmLanguage.json
+++ b/website/static/data/pintora.tmLanguage.json
@@ -21,6 +21,9 @@
           },
           "patterns": [
             {
+              "include": "#common__title"
+            },
+            {
               "include": "#activity__element"
             },
             {
@@ -40,7 +43,11 @@
               "name": "keyword.control.pintora"
             }
           },
+          "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
           "patterns": [
+            {
+              "include": "#common__title"
+            },
             {
               "include": "#component__element"
             },
@@ -50,8 +57,7 @@
             {
               "include": "#comment"
             }
-          ],
-          "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)"
+          ]
         },
         {
           "comment": "DOT Diagram",
@@ -106,6 +112,9 @@
             }
           },
           "patterns": [
+            {
+              "include": "#common__title"
+            },
             {
               "comment": "entityName relSpec entityName: role",
               "match": "(\\w+)\\s*([^\\s]+)\\s*(.*)\\s*(:)\\s*(.*)",
@@ -342,6 +351,9 @@
             },
             {
               "include": "#comment"
+            },
+            {
+              "include": "#common__title"
             }
           ]
         },
@@ -355,6 +367,9 @@
           },
           "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
           "patterns": [
+            {
+              "include": "#common__title"
+            },
             {
               "comment": "multiline text",
               "begin": "(:)",
@@ -1457,6 +1472,25 @@
           "captures": {
             "1": {
               "name": "support.type.property-name.pintora"
+            },
+            "2": {
+              "name": "keyword.control.pintora"
+            },
+            "3": {
+              "name": "string"
+            }
+          }
+        }
+      ]
+    },
+    "common__title": {
+      "patterns": [
+        {
+          "comment": "common title statement",
+          "match": "(title)\\s*(:)\\s*(.*)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.pintora"
             },
             "2": {
               "name": "keyword.control.pintora"


### PR DESCRIPTION
Related #151
- activityiagram
- erDiagram
- componentDiagram
- mindmap
