### PR TITLE
fix activity fork

### DIFF
--- a/.changeset/chilly-cherries-rule.md
+++ b/.changeset/chilly-cherries-rule.md
@@ -1,0 +1,7 @@
+---
+'@pintora/diagrams': patch
+'@pintora/cli': patch
+'@pintora/standalone': patch
+---
+
+fix: [activity] Incorrect display of forks inside groups

--- a/.changeset/slow-mice-listen.md
+++ b/.changeset/slow-mice-listen.md
@@ -1,0 +1,7 @@
+---
+'@pintora/diagrams': patch
+'@pintora/cli': patch
+'@pintora/standalone': patch
+---
+
+fix: [diagram] make sure diagram title won't be cropped when it's wider than other contents

--- a/demo/cypress/e2e/activity/activity.spec.ts
+++ b/demo/cypress/e2e/activity/activity.spec.ts
@@ -65,5 +65,22 @@ end`),
   endfork`),
       existSelectors: ['.activity__keyword'],
     },
+    {
+      // issue #169
+      description: 'Should render fork inside group correctly',
+      code: stripStartEmptyLines(`
+  activityDiagram
+  title: Fork inside group test
+  start
+  group Group {
+    fork
+      :a;
+    forkagain
+      :b;
+    endfork
+  }
+  end`),
+      existSelectors: ['.activity__keyword'],
+    },
   ])
 })

--- a/packages/pintora-diagrams/src/activity/artist.ts
+++ b/packages/pintora-diagrams/src/activity/artist.ts
@@ -733,16 +733,26 @@ class ActivityDraw {
     )
     const labelTextDims = calcTextDims(groupLabel, fontConfig)
 
+    const labelId = `${id}-label`
+    this.g.setNode(labelId, {
+      id: labelId,
+      mark: labelMark,
+      width: labelTextDims.width,
+      height: labelTextDims.height,
+    })
+
     this.g.setNode(id, {
       id,
+      mark: group,
       onLayout(data: LayoutNode) {
         const { x, y, width, height } = data
         const containerWidth = Math.max(width, labelTextDims.width + 10)
         safeAssign(bgMark.attrs, { x: x - containerWidth / 2, y: y - height / 2, width: containerWidth, height })
-
         safeAssign(labelMark.attrs, { x: x - containerWidth / 2 + 5, y: y - height / 2 + labelTextDims.height + 8 })
       },
     })
+
+    this.g.setParent(labelId, id)
 
     group.children.push(bgMark, labelMark)
     parentMark.children.push(group)
@@ -1038,17 +1048,18 @@ class ActivityDraw {
 
     const getBorderShrinkedWidth = (bounds: LayoutNode) => {
       // console.log('[getBorderShrinkedWidth] bounds', bounds, 'frameId', frameId)
-      const shrinkedWidth = bounds.width - 2 * conf.edgesep
-      const x = bounds.x + conf.actionPaddingX // TODO: why this hack
+      const shrinkedWidth = bounds.width
+      const x = bounds.x
       return { ...bounds, width: shrinkedWidth, x }
     }
 
     this.g.setNode(id, {
       id: id,
-      mark: group,
+      mark: startMark,
       width: startMark.attrs.width,
       height: startMark.attrs.height,
       onLayout: data => {
+        // console.log('[drawFork] start onLayout', data, id)
         const fb = getBorderShrinkedWidth(getFrameBounds())
         if (fb) {
           safeAssign(startMark.attrs, { x: fb.x - fb.width / 2, y: data.y - data.height / 2, width: fb.width })

--- a/packages/pintora-diagrams/src/activity/artist.ts
+++ b/packages/pintora-diagrams/src/activity/artist.ts
@@ -47,6 +47,7 @@ import {
   adjustRootMarkBounds,
   getBaseNote,
   makeCircle,
+  makeTitleMark,
 } from '../util/artist-util'
 import { makeBounds, positionGroupContents, tryExpandBounds } from '../util/mark-positioner'
 import { isDev } from '../util/env'
@@ -122,23 +123,14 @@ const erArtist: IDiagramArtist<ActivityDiagramIR, ActivityConf> = {
     const bounds = floorValues(tryExpandBounds(dagreWrapper.getGraphBounds(), edgeBounds))
     const { title } = ir
     let titleSize: Maybe<TSize> = undefined
+    let titleMark: Text | undefined = undefined
     if (title) {
       const titleFont: IFont = { fontSize: conf.fontSize, fontFamily: conf.fontFamily }
-      titleSize = calculateTextDimensions(title, titleFont)
-      const titleHeight = titleSize.height
-      rootMark.children.push({
-        type: 'text',
-        attrs: {
-          text: title,
-          x: bounds.left + bounds.width / 2,
-          y: -titleHeight,
-          ...titleFont,
-          fill: conf.textColor,
-          textAlign: 'center',
-          fontWeight: 'bold',
-        },
-        class: 'activity__title',
-      })
+      const titleResult = makeTitleMark(title, titleFont, { fill: conf.textColor })
+      titleSize = titleResult.titleSize
+      titleMark = titleResult.mark
+      titleMark.class = 'activity__title'
+      rootMark.children.push(titleMark)
       titleSize.height += conf.fontSize
     }
 
@@ -151,6 +143,7 @@ const erArtist: IDiagramArtist<ActivityDiagramIR, ActivityConf> = {
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
       titleSize,
+      titleMark,
     })
 
     return {

--- a/packages/pintora-diagrams/src/activity/config.ts
+++ b/packages/pintora-diagrams/src/activity/config.ts
@@ -36,7 +36,7 @@ export type ActivityConf = {
 export const defaultConfig: ActivityConf = {
   diagramPadding: 15,
 
-  edgesep: 60,
+  edgesep: 30,
   edgeType: 'polyline',
   useMaxWidth: false,
 

--- a/packages/pintora-diagrams/src/component/artist.ts
+++ b/packages/pintora-diagrams/src/component/artist.ts
@@ -24,7 +24,14 @@ import {
   LayoutNode,
   LayoutNodeOption,
 } from '../util/graph'
-import { makeMark, drawArrowTo, calcDirection, makeLabelBg, adjustRootMarkBounds } from '../util/artist-util'
+import {
+  makeMark,
+  drawArrowTo,
+  calcDirection,
+  makeLabelBg,
+  adjustRootMarkBounds,
+  makeTitleMark,
+} from '../util/artist-util'
 import { makeBounds, tryExpandBounds } from '../util/mark-positioner'
 import { getPointsCurvePath, getPointsLinearPath } from '../util/line-util'
 import { DagreWrapper } from '../util/dagre-wrapper'
@@ -89,23 +96,14 @@ const componentArtist: IDiagramArtist<ComponentDiagramIR, ComponentConf> = {
 
     const { title } = ir
     let titleSize: Maybe<TSize> = undefined
+    let titleMark: Text | undefined = undefined
     if (title) {
       const titleFont: IFont = { fontSize: conf.fontSize, fontFamily: conf.fontFamily }
-      titleSize = calculateTextDimensions(title, titleFont)
-      const titleHeight = titleSize.height
-      rootMark.children.push({
-        type: 'text',
-        attrs: {
-          text: title,
-          x: gBounds.left + gBounds.width / 2,
-          y: -titleHeight,
-          ...titleFont,
-          fill: conf.textColor,
-          textAlign: 'center',
-          fontWeight: 'bold',
-        },
-        class: 'component__title',
-      })
+      const titleResult = makeTitleMark(title, titleFont, { fill: conf.textColor })
+      titleSize = titleResult.titleSize
+      titleMark = titleResult.mark
+      titleMark.class = 'component__title'
+      rootMark.children.push(titleMark)
       titleSize.height += conf.fontSize
     }
 
@@ -117,6 +115,7 @@ const componentArtist: IDiagramArtist<ComponentDiagramIR, ComponentConf> = {
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
       titleSize,
+      titleMark,
     })
 
     return {

--- a/packages/pintora-diagrams/src/er/artist.ts
+++ b/packages/pintora-diagrams/src/er/artist.ts
@@ -24,6 +24,7 @@ import {
   adjustRootMarkBounds,
   makeEmptyGroup,
   makeTriangle,
+  makeTitleMark,
 } from '../util/artist-util'
 import { drawMarkerTo, CELL_ORDER, CellName, TableBuilder, TableCell, TableRow } from './artist-util'
 import { getPointsCurvePath, getPointsLinearPath } from '../util/line-util'
@@ -109,23 +110,14 @@ const erArtist: IDiagramArtist<ErDiagramIR, ErConf> = {
 
     const { title } = ir
     let titleSize: Maybe<TSize> = undefined
+    let titleMark: Text | undefined = undefined
     if (title) {
       const titleFont: IFont = { fontSize: conf.fontSize, fontFamily: conf.fontFamily }
-      titleSize = getTextDimensionsInPresicion(title, titleFont)
-      const titleHeight = titleSize.height
-      rootMark.children.push({
-        type: 'text',
-        attrs: {
-          text: title,
-          x: bounds.left + bounds.width / 2,
-          y: -titleHeight,
-          ...titleFont,
-          fill: conf.textColor,
-          textAlign: 'center',
-          fontWeight: 'bold',
-        },
-        class: 'er__title',
-      })
+      const titleResult = makeTitleMark(title, titleFont, { fill: conf.textColor })
+      titleSize = titleResult.titleSize
+      titleMark = titleResult.mark
+      titleMark.class = 'er__title'
+      rootMark.children.push(titleMark)
       titleSize.height += conf.fontSize
     }
 
@@ -137,6 +129,7 @@ const erArtist: IDiagramArtist<ErDiagramIR, ErConf> = {
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
       titleSize,
+      titleMark,
     })
 
     return {

--- a/packages/pintora-diagrams/src/mindmap/artist.ts
+++ b/packages/pintora-diagrams/src/mindmap/artist.ts
@@ -10,12 +10,13 @@ import {
   IFont,
   Maybe,
   TSize,
+  Text,
 } from '@pintora/core'
 import { MindmapIR, MMItem, MMTree } from './db'
 import { MindmapConf, getConf } from './config'
 import { createLayoutGraph, isGraphVertical, LayoutEdge, LayoutGraph, LayoutNode } from '../util/graph'
 // eslint-disable-next-line unused-imports/no-unused-imports
-import { makeMark, makeEmptyGroup, adjustRootMarkBounds, makeCircleInPoint } from '../util/artist-util'
+import { makeMark, makeEmptyGroup, adjustRootMarkBounds, makeCircleInPoint, makeTitleMark } from '../util/artist-util'
 import { getPointsLinearPath } from '../util/line-util'
 import db from './db'
 import { makeBounds, positionGroupContents, TRANSFORM_GRAPH } from '../util/mark-positioner'
@@ -44,25 +45,15 @@ const mmArtist: IDiagramArtist<MindmapIR, MindmapConf> = {
     const bounds = mmDraw.dagreWrapper.getGraphBounds()
     const { title } = ir
     let titleSize: Maybe<TSize> = undefined
+    let titleMark: Text | undefined = undefined
     if (title) {
-      const fontSize = conf.maxFontSize
-      const titleFont: IFont = { fontSize, fontFamily: conf.fontFamily }
-      titleSize = calculateTextDimensions(title, titleFont)
-      const titleHeight = titleSize.height
-      rootMark.children.push({
-        type: 'text',
-        attrs: {
-          text: title,
-          x: bounds.left + bounds.width / 2,
-          y: -titleHeight,
-          ...titleFont,
-          fill: conf.textColor,
-          textAlign: 'center',
-          fontWeight: 'bold',
-        },
-        class: 'component__title',
-      })
-      titleSize.height += fontSize
+      const titleFont: IFont = { fontSize: conf.maxFontSize, fontFamily: conf.fontFamily }
+      const titleResult = makeTitleMark(title, titleFont, { fill: conf.textColor })
+      titleSize = titleResult.titleSize
+      titleMark = titleResult.mark
+      titleMark.class = 'mindmap__title'
+      rootMark.children.push(titleMark)
+      titleSize.height += conf.maxFontSize
     }
 
     const { width, height } = adjustRootMarkBounds({
@@ -73,6 +64,7 @@ const mmArtist: IDiagramArtist<MindmapIR, MindmapConf> = {
       useMaxWidth: conf.useMaxWidth,
       containerSize: opts?.containerSize,
       titleSize,
+      titleMark,
     })
     return {
       width,

--- a/packages/pintora-diagrams/src/util/artist-util.ts
+++ b/packages/pintora-diagrams/src/util/artist-util.ts
@@ -15,6 +15,8 @@ import {
   Circle,
   ITheme,
   DiagramArtistOptions,
+  calculateTextDimensions,
+  IFont,
 } from '@pintora/core'
 import { toFixed } from './number'
 import { PALETTE } from './theme'
@@ -143,6 +145,7 @@ export function adjustRootMarkBounds({
   containerSize,
   useMaxWidth,
   titleSize,
+  titleMark,
 }: {
   rootMark: Group
   gBounds: Bounds
@@ -151,6 +154,7 @@ export function adjustRootMarkBounds({
   containerSize?: DiagramArtistOptions['containerSize']
   useMaxWidth?: boolean
   titleSize?: TSize
+  titleMark?: Text
 }) {
   const containerWidth = containerSize?.width
   const doublePadX = padX * 2
@@ -162,9 +166,34 @@ export function adjustRootMarkBounds({
     -Math.min(0, gBounds.top) + padY / scaleX + titleHeight,
   ])
   const width = Math.max(gBounds.width + doublePadX, titleWidth) * scaleX
+
+  if (titleMark) {
+    // by default center the title mark
+    titleMark.attrs.x = gBounds.left + width / 2 - padX
+  }
   return {
     width,
     height: gBounds.height * scaleX + padY * 2 + (titleSize?.height || 0),
+  }
+}
+
+export function makeTitleMark(title: string, titleFont: IFont, attrs: Partial<MarkAttrs>) {
+  const titleSize = calculateTextDimensions(title, titleFont)
+  const titleHeight = titleSize.height
+  return {
+    mark: {
+      type: 'text',
+      attrs: {
+        text: title,
+        x: 0,
+        y: -titleHeight,
+        ...titleFont,
+        ...attrs,
+        textAlign: 'center',
+        fontWeight: 'bold',
+      },
+    } as Text,
+    titleSize,
   }
 }
 


### PR DESCRIPTION
- fix: [activity] Incorrect display of forks inside groups
- feat: [activity] adjust group label and diagram edgesep
- fix: [diagram] make sure diagram title won't be cropped when it's wider than other contents
