### PR TITLE
fix: [activityDiagram] missing no-action-line parentId caused layout problem

### DIFF
--- a/.changeset/khaki-cars-lie.md
+++ b/.changeset/khaki-cars-lie.md
@@ -1,0 +1,7 @@
+---
+'@pintora/diagrams': patch
+'@pintora/cli': patch
+'@pintora/standalone': patch
+---
+
+fix: [activityDiagram] missing no-action-line parentId caused layout problem

--- a/packages/pintora-diagrams/src/activity/artist.ts
+++ b/packages/pintora-diagrams/src/activity/artist.ts
@@ -552,6 +552,9 @@ class ActivityDraw {
         })
         this.g.setEdge(id, dummyNode.id, { label })
         this.g.setEdge(dummyNode.id, endId)
+        if (stepModel.parentId) {
+          this.g.setParent(dummyNode.id, stepModel.parentId)
+        }
       }
     }
 


### PR DESCRIPTION
Related #265 