### PR TITLE
fix(diagrams): parse text prefix with `#`

### DIFF
--- a/.changeset/poor-gorillas-tan.md
+++ b/.changeset/poor-gorillas-tan.md
@@ -1,0 +1,5 @@
+---
+'@pintora/diagrams': patch
+---
+
+fix: parse texts prefix with `#`

--- a/packages/pintora-diagrams/shared-grammars/config.ne
+++ b/packages/pintora-diagrams/shared-grammars/config.ne
@@ -1,7 +1,7 @@
 @{%
-export const COLOR = /#[a-zA-Z0-9]+/
-export const PARAM_DIRECTIVE = /@param/
-export const CONFIG_DIRECTIVE = /@config/
+let _COLOR = /#[a-zA-Z0-9]+/
+let PARAM_DIRECTIVE = /@param/
+let CONFIG_DIRECTIVE = /@config/
 
 //@ts-ignore
 let L_PAREN = /\(/
@@ -30,8 +30,8 @@ function handleConfigOpenCloseStatement(d) {
 %}
 
 # non-terminal, needs
-# - `COLOR` token
-color -> %COLOR {% (d) => tv(d[0]) %}
+# - `_COLOR` token
+color -> %_COLOR {% (d) => tv(d[0]) %}
 
 # `@param` statement, with some prerequisites:
 # - `PARAM_DIRECTIVE` token

--- a/packages/pintora-diagrams/src/activity/parser/activityDiagram.ne
+++ b/packages/pintora-diagrams/src/activity/parser/activityDiagram.ne
@@ -240,7 +240,7 @@ wordsInParens ->
     %L_PAREN words %R_PAREN {% (d) => d[1] %}
 
 words ->
-    (%VALID_TEXT | %WS):+ {%
+    (%VALID_TEXT | %COLOR | %WS):+ {%
       function(d) {
         return d[0].map(o => tv(o[0])).join('')
       }

--- a/packages/pintora-diagrams/src/class/__tests__/class-parser.spec.ts
+++ b/packages/pintora-diagrams/src/class/__tests__/class-parser.spec.ts
@@ -176,4 +176,18 @@ classDiagram
     const result = db.getDiagramIR()
     expect(result.title).toBe('Hello')
   })
+
+  // issue #330
+  it('can parse member with #', () => {
+    const multilineNoteExample = stripStartEmptyLines(`
+classDiagram
+  class #Shape {
+    #area: double
+}
+    `)
+    parse(multilineNoteExample)
+    const result = db.getDiagramIR()
+    const { members } = result.classes['#Shape']
+    expect(members[0].raw).toEqual('#area: double')
+  })
 })

--- a/packages/pintora-diagrams/src/sequence/parser/sequenceDiagram.ne
+++ b/packages/pintora-diagrams/src/sequence/parser/sequenceDiagram.ne
@@ -65,7 +65,7 @@ let lexer = moo.states({
     WORD: { match: VALID_TEXT_REGEXP, fallback: true },
   },
   line: {
-    REST_OF_LINE: { match: /[^#\n;]+/, pop: 1 },
+    REST_OF_LINE: { match: /[^\n;]+/, pop: 1 },
   },
   configStatement: {
     ...configLexerconfigStatementState,

--- a/packages/pintora-diagrams/src/util/parser-shared.ts
+++ b/packages/pintora-diagrams/src/util/parser-shared.ts
@@ -16,6 +16,7 @@ export function textToCaseInsensitiveRegex(text) {
 
 /** token value */
 export function tv(token) {
+  // if (typeof token === 'string') return token
   if (token && 'value' in token) return token.value
   return token
 }
@@ -64,4 +65,19 @@ export function makeNth(n: number) {
   return function (d: unknown[]) {
     return d[n]
   }
+}
+
+export function flatten(list) {
+  const output = []
+
+  function walk(item) {
+    if (Array.isArray(item)) {
+      item.forEach(walk)
+    } else {
+      output.push(item)
+    }
+    return output
+  }
+
+  return walk(list)
 }


### PR DESCRIPTION
Related #330 