### PR TITLE
fix - Correction for running target-wintercg in browser service worker

### DIFF
--- a/packages/pintora-diagrams/src/util/env.ts
+++ b/packages/pintora-diagrams/src/util/env.ts
@@ -1,1 +1,1 @@
-export const isDev = typeof location !== 'undefined' && location.hostname === 'localhost'
+export const isDev = typeof location !== 'undefined' && location.hostname === 'localhost' && typeof window !== 'undefined'


### PR DESCRIPTION
Currently, in diagrams, the value of `isDev` is determined from the existence and value of `location` .  When `isDev` is true, the rest of code makes use of `window`. 

When using `target-wintercg` in a browser service worker from localhost, the library crashes on `render` because `window` doesn't exist in this sandboxed context.

This PR is to make the `isDev` determination more specific (adding a check that `window` also exists), making producing diagrams from code running as service worker possible.