### PR TITLE
feat: treat window assignment carefully

### DIFF
--- a/.changeset/serious-trains-camp.md
+++ b/.changeset/serious-trains-camp.md
@@ -1,0 +1,5 @@
+---
+'@pintora/diagrams': patch
+---
+
+feat: treat window assignment carefully

--- a/demo/src/pages/demo/components/index.tsx
+++ b/demo/src/pages/demo/components/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { setLogLevel } from '@pintora/core'
 import { EXAMPLES } from '@pintora/test-shared'
 import PintoraPreview from 'src/components/PintoraPreview'
@@ -9,5 +9,9 @@ setLogLevel('debug')
 const testSequenceDiagram = EXAMPLES.sequence.code
 
 export default function Basic() {
+  useEffect(() => {
+    // set pintora to dev mode
+    ;(globalThis as any).isPintoraDev = true
+  }, [])
   return <PintoraPreview code={testSequenceDiagram} />
 }

--- a/packages/pintora-diagrams/src/activity/artist.ts
+++ b/packages/pintora-diagrams/src/activity/artist.ts
@@ -29,7 +29,7 @@ import {
 import { calcBound, floorValues, updateBoundsByPoints } from '../util/bound'
 import type { EnhancedConf } from '../util/config'
 import { DagreWrapper } from '../util/dagre-wrapper'
-import { isDev } from '../util/env'
+import { setDevGlobal } from '../util/env'
 import { getFontConfig } from '../util/font-config'
 import { LayoutEdge, LayoutGraph, LayoutNode, createLayoutGraph, getGraphSplinesOption } from '../util/graph'
 import { getPointsCurvePath, getPointsLinearPath } from '../util/line-util'
@@ -99,9 +99,7 @@ const erArtist: IDiagramArtist<ActivityDiagramIR, ActivityConf> = {
     const dagreWrapper = new DagreWrapper(g)
     activityDraw = new ActivityDraw(model, g)
     activityDraw.fontConfig = fontConfig
-    if (isDev) {
-      ;(window as any).activityDraw = activityDraw
-    }
+    setDevGlobal('activityDraw', activityDraw)
 
     ir.steps.forEach(step => {
       activityDraw.drawStep(rootMark, step)

--- a/packages/pintora-diagrams/src/class/artist.ts
+++ b/packages/pintora-diagrams/src/class/artist.ts
@@ -25,7 +25,7 @@ import {
 import { calcBound } from '../util/bound'
 import type { EnhancedConf } from '../util/config'
 import { DagreWrapper } from '../util/dagre-wrapper'
-import { isDev } from '../util/env'
+import { setDevGlobal } from '../util/env'
 import { getFontConfig } from '../util/font-config'
 import { BaseEdgeData, createLayoutGraph, getGraphSplinesOption, LayoutGraph, LayoutNode } from '../util/graph'
 import { getMedianPoint, getPointsCurvePath, getPointsLinearPath } from '../util/line-util'
@@ -40,9 +40,7 @@ class ClassArtist extends BaseArtist<ClassIR, ClassConf> {
     const conf = getConf(ir, config)
 
     const draw = new ClassDiagramDraw(ir, conf)
-    if (isDev) {
-      ;(window as any).classDraw = draw
-    }
+    setDevGlobal('classDraw', draw)
 
     const { gBounds } = draw.drawTo(rootMark)
     const titleMaker = new DiagramTitleMaker({

--- a/packages/pintora-diagrams/src/dot/artist.ts
+++ b/packages/pintora-diagrams/src/dot/artist.ts
@@ -22,7 +22,7 @@ import {
 } from '../util/artist-util'
 import { floorValues } from '../util/bound'
 import { DagreWrapper } from '../util/dagre-wrapper'
-import { isDev } from '../util/env'
+import { setDevGlobal } from '../util/env'
 import { createLayoutGraph, getGraphSplinesOption, LayoutEdge, LayoutGraph } from '../util/graph'
 import { getPointsCurvePath, getPointsLinearPath } from '../util/line-util'
 import { TRANSFORM_GRAPH } from '../util/mark-positioner'
@@ -132,9 +132,7 @@ class DOTDraw {
     public conf: DOTConf,
     public rootMark: Group,
   ) {
-    if (isDev) {
-      ;(window as any).dotDraw = this
-    }
+    setDevGlobal('dotDraw', this)
 
     this.g = createLayoutGraph({
       multigraph: true,

--- a/packages/pintora-diagrams/src/gantt/artist.ts
+++ b/packages/pintora-diagrams/src/gantt/artist.ts
@@ -18,7 +18,7 @@ import {
 import { scaleTime, ScaleTime } from 'd3-scale'
 import dayjs from 'dayjs'
 import { drawDiamondTo, LayerManager, makeEmptyGroup } from '../util/artist-util'
-import { isDev } from '../util/env'
+import { setDevGlobal } from '../util/env'
 import { GanttConf, getConf } from './config'
 import { GanttIR, getAxisTimeInterval, isInvalidDate, Task } from './db'
 import { getFontConfig } from '../util/font-config'
@@ -78,9 +78,7 @@ class GanttDraw {
     public rootMark: Group,
     w: number,
   ) {
-    if (isDev) {
-      ;(window as any).ganttDraw = this
-    }
+    setDevGlobal('ganttDraw', this)
 
     const taskArray = Object.values(ir.tasks)
     this.taskArray = taskArray

--- a/packages/pintora-diagrams/src/mindmap/artist.ts
+++ b/packages/pintora-diagrams/src/mindmap/artist.ts
@@ -15,7 +15,7 @@ import { MindmapIR, MMItem, MMTree } from './db'
 import { adjustRootMarkBounds, DiagramTitleMaker, makeEmptyGroup, makeMark } from '../util/artist-util'
 import { BaseArtist } from '../util/base-artist'
 import { DagreWrapper } from '../util/dagre-wrapper'
-import { isDev } from '../util/env'
+import { setDevGlobal } from '../util/env'
 import { getFontConfig } from '../util/font-config'
 import { getPointsLinearPath } from '../util/line-util'
 import { makeBounds, positionGroupContents, TRANSFORM_GRAPH } from '../util/mark-positioner'
@@ -30,9 +30,7 @@ class MindmapArtist extends BaseArtist<MindmapIR, MindmapConf> {
     mmDraw = new MMDraw(ir)
     const fontConfig = getFontConfig(conf)
     mmDraw.fontConfig = fontConfig
-    if (isDev) {
-      ;(window as any).mmDraw = mmDraw
-    }
+    setDevGlobal('mmDraw', mmDraw)
 
     const rootMark: Group = {
       type: 'group',

--- a/packages/pintora-diagrams/src/util/env.ts
+++ b/packages/pintora-diagrams/src/util/env.ts
@@ -1,1 +1,10 @@
-export const isDev = typeof location !== 'undefined' && location.hostname === 'localhost' && typeof window !== 'undefined'
+export const isDev = globalThis.isPintoraDev ?? false
+
+export const pintoraDevGlobals = {}
+
+export function setDevGlobal(key: string, value: unknown) {
+  pintoraDevGlobals[key] = value
+  if (isDev) {
+    globalThis.pintoraDevGlobals = pintoraDevGlobals
+  }
+}


### PR DESCRIPTION
Attach dev globals with `globalThis` instead of `window`, so we don't break target-wintercg running in service-worker or so.