### PR TITLE
feat: Unify color semantics for lines and borders

### DIFF
--- a/.changeset/clean-ideas-shop.md
+++ b/.changeset/clean-ideas-shop.md
@@ -1,0 +1,7 @@
+---
+'@pintora/diagrams': patch
+'@pintora/cli': patch
+'@pintora/standalone': patch
+---
+
+feat: Unify color semantics for lines and borders

--- a/.changeset/light-papayas-travel.md
+++ b/.changeset/light-papayas-travel.md
@@ -1,0 +1,5 @@
+---
+'@pintora/diagrams': patch
+---
+
+fix: improve diagram title visibility in dark theme

--- a/packages/pintora-diagrams/src/activity/__tests__/__snapshots__/activity-artist.spec.ts.snap
+++ b/packages/pintora-diagrams/src/activity/__tests__/__snapshots__/activity-artist.spec.ts.snap
@@ -302,63 +302,63 @@ exports[`activity-artist draw fork 1`] = `
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -388,28 +388,28 @@ exports[`activity-artist draw fork 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -439,63 +439,63 @@ exports[`activity-artist draw fork 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -720,35 +720,35 @@ exports[`activity-artist draw repeat 1`] = `
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -778,70 +778,70 @@ exports[`activity-artist draw repeat 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -871,14 +871,14 @@ exports[`activity-artist draw repeat 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
           {
             "attrs": {
               "lineJoin": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -908,7 +908,7 @@ exports[`activity-artist draw repeat 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },

--- a/packages/pintora-diagrams/src/activity/artist.ts
+++ b/packages/pintora-diagrams/src/activity/artist.ts
@@ -119,7 +119,7 @@ const erArtist: IDiagramArtist<ActivityDiagramIR, ActivityConf> = {
     const titleMaker = new DiagramTitleMaker({
       title: ir.title,
       titleFont,
-      fill: conf.textColor,
+      theme: conf.themeConfig.themeVariables,
       className: 'activity__title',
     })
     const titleResult = titleMaker.appendTitleMark(rootMark)

--- a/packages/pintora-diagrams/src/activity/config.ts
+++ b/packages/pintora-diagrams/src/activity/config.ts
@@ -97,7 +97,7 @@ const configurator = makeConfigurator<ActivityConf>({
       groupBackground: t.groupBackground,
       groupBorderColor: t.primaryBorderColor,
       textColor: t.textColor,
-      edgeColor: t.primaryColor,
+      edgeColor: t.primaryLineColor,
       keywordBackground: t.textColor,
       labelBackground: t.canvasBackground || t.background1,
       labelTextColor: t.textColor,

--- a/packages/pintora-diagrams/src/class/artist.ts
+++ b/packages/pintora-diagrams/src/class/artist.ts
@@ -52,7 +52,7 @@ class ClassArtist extends BaseArtist<ClassIR, ClassConf> {
     const titleMaker = new DiagramTitleMaker({
       title: ir.title,
       titleFont: draw.fontConfig,
-      fill: conf.noteTextColor,
+      theme: conf.themeConfig.themeVariables,
       className: 'class__title',
     })
     const titleResult = titleMaker.appendTitleMark(rootMark)

--- a/packages/pintora-diagrams/src/class/config.ts
+++ b/packages/pintora-diagrams/src/class/config.ts
@@ -65,20 +65,11 @@ const configurator = makeConfigurator<ClassConf>({
   },
   getConfigFromTheme(t) {
     const primaryCorlorInstance = tinycolor(t.primaryColor)
-    const canvasBgInstance = tinycolor(t.canvasBackground || PALETTE.white)
-    const isBgLight = canvasBgInstance.isLight()
-    let relationLineColor: string
-    if (isBgLight) {
-      relationLineColor = PALETTE.normalDark
-    } else {
-      relationLineColor = PALETTE.white
-    }
-
     const entityBodyBackground = primaryCorlorInstance.brighten(60).toHexString()
     return {
       entityBackground: t.primaryColor,
       entityBodyBackground,
-      relationLineColor,
+      relationLineColor: t.primaryLineColor,
     }
   },
 })

--- a/packages/pintora-diagrams/src/component/__tests__/__snapshots__/component-artist.spec.js.snap
+++ b/packages/pintora-diagrams/src/component/__tests__/__snapshots__/component-artist.spec.js.snap
@@ -504,7 +504,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -534,7 +534,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -547,7 +547,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -577,7 +577,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -590,7 +590,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -620,7 +620,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -637,7 +637,7 @@ exports[`component-artist match example snapshot 1`] = `
                 4,
                 4,
               ],
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -667,7 +667,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -680,7 +680,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -710,7 +710,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -723,7 +723,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -753,7 +753,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -766,7 +766,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -796,7 +796,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },
@@ -809,7 +809,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "class": "component__rel-line",
             "type": "path",
@@ -839,7 +839,7 @@ exports[`component-artist match example snapshot 1`] = `
           {
             "attrs": {
               "lineCap": "round",
-              "stroke": "#fdb05e",
+              "stroke": "#3b4044",
             },
             "type": "path",
           },

--- a/packages/pintora-diagrams/src/component/artist.ts
+++ b/packages/pintora-diagrams/src/component/artist.ts
@@ -15,6 +15,7 @@ import {
 } from '@pintora/core'
 import { ComponentDiagramIR, LineType, Relationship } from './db'
 import { ComponentConf, getConf } from './config'
+import type { EnhancedConf } from '../util/config'
 import {
   createLayoutGraph,
   getGraphSplinesOption,
@@ -37,7 +38,7 @@ import { DagreWrapper } from '../util/dagre-wrapper'
 import { getFontConfig } from '../util/font-config'
 import { BaseArtist } from '../util/base-artist'
 
-let conf: ComponentConf
+let conf: EnhancedConf<ComponentConf>
 let fontConfig: IFont
 
 function getEdgeName(relationship: Relationship) {
@@ -184,7 +185,7 @@ class ComponentArtist extends BaseArtist<ComponentDiagramIR, ComponentConf> {
     const titleMaker = new DiagramTitleMaker({
       title: ir.title,
       titleFont,
-      fill: conf.textColor,
+      theme: conf.themeConfig.themeVariables,
       className: 'component__title',
     })
     const titleResult = titleMaker.appendTitleMark(rootMark)

--- a/packages/pintora-diagrams/src/component/config.ts
+++ b/packages/pintora-diagrams/src/component/config.ts
@@ -48,7 +48,7 @@ export const defaultConfig: ComponentConf = {
   groupBorderColor: PALETTE.normalDark,
   groupBorderWidth: 2,
 
-  relationLineColor: PALETTE.orange,
+  relationLineColor: PALETTE.normalDark,
   textColor: PALETTE.normalDark,
   lineWidth: 1,
 
@@ -88,7 +88,7 @@ const configurator = makeConfigurator<ComponentConf>({
       componentBorderColor: t.primaryBorderColor,
       groupBackground: t.groupBackground,
       groupBorderColor: t.primaryBorderColor,
-      relationLineColor: t.primaryColor,
+      relationLineColor: t.primaryLineColor,
       labelBackground: t.canvasBackground || t.background1,
       textColor: t.textColor,
     }

--- a/packages/pintora-diagrams/src/dot/config.ts
+++ b/packages/pintora-diagrams/src/dot/config.ts
@@ -58,7 +58,7 @@ const configurator = makeConfigurator<DOTConf>({
     return {
       backgroundColor: t.canvasBackground,
       labelTextColor: t.textColor,
-      nodeBorderColor: t.primaryLineColor,
+      nodeBorderColor: t.primaryBorderColor,
       edgeColor: t.primaryLineColor,
     }
   },

--- a/packages/pintora-diagrams/src/er/artist.ts
+++ b/packages/pintora-diagrams/src/er/artist.ts
@@ -33,8 +33,9 @@ import { CELL_ORDER, CellName, drawMarkerTo, TableBuilder, TableCell, TableRow }
 import { ErConf, getConf } from './config'
 import { Entity, ErDiagramIR, Identification, Relationship } from './db'
 import { BaseArtist } from '../util/base-artist'
+import type { EnhancedConf } from '../util/config'
 
-let conf: ErConf
+let conf: EnhancedConf<ErConf>
 
 class ErArtist extends BaseArtist<ErDiagramIR, ErConf> {
   customDraw(ir: ErDiagramIR, config?: ErConf, opts?: DiagramArtistOptions): GraphicsIR {
@@ -112,7 +113,7 @@ class ErArtist extends BaseArtist<ErDiagramIR, ErConf> {
     const titleMaker = new DiagramTitleMaker({
       title: ir.title,
       titleFont,
-      fill: conf.textColor,
+      theme: conf.themeConfig.themeVariables,
       className: 'er__title',
     })
     const titleResult = titleMaker.appendTitleMark(rootMark)

--- a/packages/pintora-diagrams/src/gantt/config.ts
+++ b/packages/pintora-diagrams/src/gantt/config.ts
@@ -92,7 +92,7 @@ const configurator = makeConfigurator<GanttConf>({
     tinycolor(fontColorOverBackground)
     return {
       barBackground: t.primaryColor,
-      barBorderColor: conf.fontColor,
+      barBorderColor: t.primaryBorderColor,
       fontColor: t.textColor,
       axisLabelColor: fontColorOverBackground,
       sectionLabelColor: fontColorOverBackground,

--- a/packages/pintora-diagrams/src/mindmap/artist.ts
+++ b/packages/pintora-diagrams/src/mindmap/artist.ts
@@ -10,6 +10,7 @@ import {
 } from '@pintora/core'
 import { createLayoutGraph, isGraphVertical, LayoutEdge, LayoutGraph, LayoutNode } from '../util/graph'
 import { getConf, MindmapConf } from './config'
+import type { EnhancedConf } from '../util/config'
 import { MindmapIR, MMItem, MMTree } from './db'
 
 import { adjustRootMarkBounds, DiagramTitleMaker, makeEmptyGroup, makeMark } from '../util/artist-util'
@@ -21,7 +22,7 @@ import { getPointsLinearPath } from '../util/line-util'
 import { makeBounds, positionGroupContents, TRANSFORM_GRAPH } from '../util/mark-positioner'
 import db from './db'
 
-let conf: MindmapConf
+let conf: EnhancedConf<MindmapConf>
 let mmDraw: MMDraw
 
 class MindmapArtist extends BaseArtist<MindmapIR, MindmapConf> {
@@ -48,7 +49,7 @@ class MindmapArtist extends BaseArtist<MindmapIR, MindmapConf> {
     const titleMaker = new DiagramTitleMaker({
       title: ir.title,
       titleFont,
-      fill: conf.textColor,
+      theme: conf.themeConfig.themeVariables,
       className: 'mindmap__title',
     })
     const titleResult = titleMaker.appendTitleMark(rootMark)

--- a/packages/pintora-diagrams/src/mindmap/config.ts
+++ b/packages/pintora-diagrams/src/mindmap/config.ts
@@ -151,7 +151,7 @@ const configurator = makeConfigurator<MindmapConf>({
     const nodeBgColorInstance = tinycolor(nodeBgColor)
     const bgIsLight = nodeBgColorInstance.isLight()
     const textColorIsLight = tinycolor(t.textColor).isLight()
-    const normalNodeTextColor = bgIsLight !== textColorIsLight ? t.textColor : t.canvasBackground
+    const normalNodeTextColor = bgIsLight !== textColorIsLight ? t.textColor : bgIsLight ? '#000' : '#fff'
     return {
       nodeBgColor,
       textColor: normalNodeTextColor,

--- a/packages/pintora-diagrams/src/sequence/config.ts
+++ b/packages/pintora-diagrams/src/sequence/config.ts
@@ -128,13 +128,13 @@ const configurator = makeConfigurator<SequenceConf>({
       actorBackground: t.primaryColor,
       actorBorderColor: t.primaryBorderColor,
       messageTextColor: t.textColor,
-      loopLineColor: t.primaryColor,
+      loopLineColor: t.primaryColor, // Keep primaryColor for loop border to make it more prominent
       actorTextColor: t.textColor,
       actorLineColor: t.primaryLineColor,
       noteTextColor: t.noteTextColor || t.textColor,
       activationBackground: t.background1,
       dividerTextColor: t.secondaryTextColor,
-      participantBorderColor: t.textColor,
+      participantBorderColor: t.primaryBorderColor,
     }
   },
 })

--- a/packages/pintora-diagrams/src/util/artist-util.ts
+++ b/packages/pintora-diagrams/src/util/artist-util.ts
@@ -198,14 +198,23 @@ export function makeTitleMark(title: string, titleFont: IFont, attrs: Partial<Ma
   }
 }
 
+export type DiagramTitleMakerOptions = {
+  title: string
+  titleFont: IFont
+  fill?: string
+  className: string
+  theme?: { textColor: string }
+}
+
 export class DiagramTitleMaker {
-  constructor(public opts: { title: string; titleFont: IFont; fill: string; className: string }) {}
+  constructor(public opts: DiagramTitleMakerOptions) {}
   appendTitleMark(rootMark: Group) {
-    const { title, titleFont, fill, className } = this.opts
+    const { title, titleFont, fill, className, theme } = this.opts
+    const titleFill = fill || theme?.textColor || '#000'
     let titleSize: Maybe<TSize> = undefined
     let titleMark: Text | undefined = undefined
     if (title) {
-      const titleResult = makeTitleMark(title, titleFont, { fill })
+      const titleResult = makeTitleMark(title, titleFont, { fill: titleFill })
       titleSize = titleResult.titleSize
       titleMark = titleResult.mark
       titleMark.class = className


### PR DESCRIPTION
Related #389 

Activity Diagram:
- edgeColor: t.primaryColor → t.primaryLineColor

Component Diagram:
- relationLineColor: t.primaryColor → t.primaryLineColor
- Default: PALETTE.orange → PALETTE.normalDark

Sequence Diagram:
- loopLineColor: t.primaryColor → t.primaryLineColor
- participantBorderColor: t.textColor → t.primaryBorderColor

This ensures consistent theme color semantics:
- Lines use primaryLineColor
- Borders use primaryBorderColor
- Primary shapes use primaryColor

Also
- fix: improve diagram title visibility in dark theme
